### PR TITLE
Fixed issue in AddResult.cs

### DIFF
--- a/Matchmaker/Actions/AddResults.cs
+++ b/Matchmaker/Actions/AddResults.cs
@@ -31,8 +31,8 @@ namespace Matchmaker.Actions
             IDictionary<Player, Rating> newRating = TrueSkillCalculator.CalculateNewRatings(
                 GameInfo.DefaultGameInfo,
                 Matchmaker.Logic.Teams.ConvertToMoserware(),
-                color.Value == TeamColor.Blue ? 2 : 1,
-                color.Value == TeamColor.Blue ? 1 : 2);
+                color.Value is TeamColor.Blue ? 1 : 2,
+                color.Value is TeamColor.Red ? 1 : 2);
 
             using (Context context = new Context())
             {


### PR DESCRIPTION
Minor error fixed where originally the opposite teams Mean would increase as the ratings calculator would mark the opposite team winning instead of the actual team that was entered.

Example: When Blue team won the game. The code would mark blue team as being in second place (lost). Also, because the second check is also asking for blue teams stats. They would be marked as winning, however this is not the case. The final scores would be (2,1). Moserware Skills would interpret this as Blue Team Loosing and Red Team winning. Because Blue came second, and Red came first. This was fixed by Changing the team color and the conditional operator expression. Blue is now first place (winner) when the color value is Blue and Red Team is now first place (winner) when the color value is Red.

Hope I explained that clearly.